### PR TITLE
[FIX] Allow 0 as iBeacon major and minor versions

### DIFF
--- a/app/src/main/java/org/turbo/beaconmqtt/beacon/IBeacon.java
+++ b/app/src/main/java/org/turbo/beaconmqtt/beacon/IBeacon.java
@@ -70,8 +70,8 @@ public final class IBeacon extends BaseBleBeacon {
     public boolean isValid() {
         boolean isValid = super.isValid();
         isValid &= Helper.validateUuid(iBeaconData.mUuid);
-        isValid &= Helper.validateInt(iBeaconData.mMajor, 1, 65535);
-        isValid &= Helper.validateInt(iBeaconData.mMinor, 1, 65535);
+        isValid &= Helper.validateInt(iBeaconData.mMajor, 0, 65535);
+        isValid &= Helper.validateInt(iBeaconData.mMinor, 0, 65535);
         isValid &= Helper.validateMacAddress(mBluetoothAddress);
         return isValid;
     }


### PR DESCRIPTION
Hi! I had trouble creating iBeacon filters because some devices have minor versions set to 0. While at it, I also allowed major versions to be 0 too, just in case. Regards!